### PR TITLE
Add Load dot env

### DIFF
--- a/env.d.ts
+++ b/env.d.ts
@@ -1,0 +1,12 @@
+declare module 'process' {
+    global {
+      namespace NodeJS {
+        interface ProcessEnv {
+          TEST_KEY: string;
+          API_KEY: string;
+          NODE_ENV?: string;
+        }
+      }
+    }
+  }
+  

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@emotion/react": "^11.13.5",
+        "dotenv": "^16.4.7",
         "google-auth-library": "^9.15.0",
         "google-spreadsheet": "^4.1.4",
         "react": "^18.3.1",
@@ -24,7 +25,7 @@
         "ts-jest": "^29.2.5",
         "ts-loader": "^9.5.1",
         "ts-node": "^10.9.2",
-        "typescript": "^5.6.3",
+        "typescript": "^5.7.2",
         "webpack": "^5.97.0",
         "webpack-cli": "^5.1.4"
       }
@@ -2733,6 +2734,18 @@
       "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.4.7",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
+      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/ecdsa-sig-formatter": {
@@ -6298,9 +6311,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
-      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
+      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -19,12 +19,13 @@
     "ts-jest": "^29.2.5",
     "ts-loader": "^9.5.1",
     "ts-node": "^10.9.2",
-    "typescript": "^5.6.3",
+    "typescript": "^5.7.2",
     "webpack": "^5.97.0",
     "webpack-cli": "^5.1.4"
   },
   "dependencies": {
     "@emotion/react": "^11.13.5",
+    "dotenv": "^16.4.7",
     "google-auth-library": "^9.15.0",
     "google-spreadsheet": "^4.1.4",
     "react": "^18.3.1",

--- a/src/loadDotEnv.ts
+++ b/src/loadDotEnv.ts
@@ -1,4 +1,11 @@
 // .envを読み込む
 // うまくやればprocess.env.{"キー"}でアクセスできそう（？）
+import dotenv from 'dotenv';
+
 export function loadDotEnv() {
+
+dotenv.config();
+
+console.log(process.env.TEST_KEY); // HelloWorld
+
 }

--- a/src/loadDotEnv.ts
+++ b/src/loadDotEnv.ts
@@ -4,8 +4,8 @@ import dotenv from 'dotenv';
 
 export function loadDotEnv() {
 
-dotenv.config();
+    dotenv.config();
 
-console.log(process.env.TEST_KEY); // HelloWorld
+    //console.log(process.env.TEST_KEY); // HelloWorld
 
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,8 @@
         "strict": true,
         "paths": {
             "@/*": ["./*"]
-        }
+        },
+        "typeRoots": ["./node_modules/@types", "./types"]
     },
     "ts-node": {
         "compilerOptions": {

--- a/types/env.d.ts
+++ b/types/env.d.ts
@@ -1,0 +1,12 @@
+declare module 'process' {
+    global {
+      namespace NodeJS {
+        interface ProcessEnv {
+          TEST_KEY: string;
+          API_KEY: string;
+          NODE_ENV?: string;
+        }
+      }
+    }
+  }
+  

--- a/types/env.d.ts
+++ b/types/env.d.ts
@@ -1,12 +1,8 @@
-declare module 'process' {
-    global {
-      namespace NodeJS {
-        interface ProcessEnv {
-          TEST_KEY: string;
-          API_KEY: string;
-          NODE_ENV?: string;
-        }
-      }
-    }
+declare namespace NodeJS {
+  interface ProcessEnv {
+    TEST_KEY: string;
+    API_KEY: string;
+    NODE_ENV?: string;
   }
+}
   


### PR DESCRIPTION
## 作成した内容
- env.d.tsを作成し，型定義を拡張した
- tsconfig.jsonにtypeRootsを追加し，env.d.tsを認識させた
- `npm install dotenv`でdotenvモジュールをインストールした
- loadDotEnv.tsを作成し，envファイルを読み取れるようにした

## 参考資料
- [envファイルとはなに？？](https://qiita.com/harut_1111/items/e0abddfd0311eb4fb32b)
- [dotenvモジュールのインストール](https://maku77.github.io/nodejs/env/dotenv.html)
`npm install dotenv`
- [型定義の拡張 env.d.tsの作成](https://zenn.dev/ken7253/articles/env-variable-type-definition)
- [process.envとはなに？？](https://qiita.com/theFirstPenguin/items/89444431a6a590aa4784)
`process.env.API_KEY で利用する`