### PR TITLE
docToPostersを実装

### DIFF
--- a/src/docToPosters.ts
+++ b/src/docToPosters.ts
@@ -3,6 +3,17 @@ import { GoogleSpreadsheet } from "google-spreadsheet";
 import { Poster } from "@/types/Poster";
 
 // GoogleSpreadsheetから情報を抜き出しArray<Poster>の形で返す
-export function docToPosters(doc: GoogleSpreadsheet): Array<Poster> {
-    return [];
+export async function docToPosters(doc: GoogleSpreadsheet): Promise<Array<Poster>> {
+    const sheetName = "left"; // 使うシート名の指定
+    const headers = ["title", "Text", "user", "timestamp"]; // シートのヘッダー名の指定
+
+    const sheet = doc.sheetsByTitle[sheetName];
+    const rows = await sheet.getRows();
+
+    return rows.map((row) => ({
+        title: row.get(headers[0]) as string,
+        message: row.get(headers[1]) as string,
+        author: row.get(headers[2]) as string,
+        createAt: row.get(headers[3]) as string
+    }));
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -53,7 +53,7 @@ ipcMain.handle("get_posters", async () => {
     await doc.loadInfo();
 
     // データ整形
-    const posters = docToPosters(doc);
+    const posters = await docToPosters(doc);
 
     return posters;
 });


### PR DESCRIPTION
## 内容
- `src/docToPosters.ts`を実装
- `docToPosters`を非同期に変更 (それにともなって`src/main.ts`も少し変更)

## その他
- ローカルで`main.ts`の50行目くらいを以下のように変更して別のスプレッドシートで確認したところうまく動いていました
```
    // ログイン・ダウンロード処理
    // const auth = createAccountAuth();
    // const doc = new GoogleSpreadsheet("" /* ← sheetIDに書き換え */, auth);
    const doc = new GoogleSpreadsheet("TEST SHEET ID", { apiKey: "TEST API KEY" });
    await doc.loadInfo();
```
- `google-spreadsheet`でシートからデータを取得するときに使う`getRows`メソッドは非同期らしいのでそれにあわせて各所変更しました

## 参考資料
- <https://theoephraim.github.io/node-google-spreadsheet/>